### PR TITLE
Fix bug ricerca prodotti

### DIFF
--- a/src/app/components/search-products/search-products.component.html
+++ b/src/app/components/search-products/search-products.component.html
@@ -18,9 +18,9 @@
             <mat-option *ngFor="let cat of categories" [value]="cat.id">{{cat.description}}</mat-option>
           </mat-select>
         </mat-form-field>
-        <mat-form-field>
+        <!-- <mat-form-field>
           <input matInput color="accent" type="text" id="prodDescr" aria-label="cerca per descrizione" [(ngModel)]="productDescription" placeholder="Descrizione Prodotto" name="prodDescr"/>
-        </mat-form-field>
+        </mat-form-field> -->
       </mat-expansion-panel>
       <button mat-raised-button aria-label="cerca" type="submit" color="accent"><mat-icon>search</mat-icon></button>
     </form>

--- a/src/app/components/search-products/search-products.component.html
+++ b/src/app/components/search-products/search-products.component.html
@@ -5,7 +5,7 @@
       <mat-form-field>
         <input matInput color="accent" type="text" id="prodName" aria-label="cerca per nome" [(ngModel)]="productName" placeholder="Nome Prodotto" name="prodName"/>
       </mat-form-field>
-      <mat-expansion-panel >
+      <mat-expansion-panel *ngIf="!idLockedCategory"> <!--delete this check once more options become available-->
         <mat-expansion-panel-header>
           <mat-panel-title>
             Opzioni aggiuntive

--- a/src/app/components/search-products/search-products.component.ts
+++ b/src/app/components/search-products/search-products.component.ts
@@ -57,6 +57,9 @@ export class SearchProductsComponent extends InfiniteScrollableComponent<Product
 
   private prepareQuery() : ProductsRequest {
     let query : ProductsRequest = {idsSalesPoint : [this.idSp]};
+    if (this.productName) {
+      query.description = `%${this.productName}%`;
+    }
     if (this.idCategory) {
       query.idsCategory = [this.idCategory];
     }
@@ -86,14 +89,11 @@ function prepareProduct(prod : Product) : Product {
       }
     }
   }
-  console.log("price:" + res.basePrice)
-
   return res;
 }
 
 function filterProducts(products: Product[]): Product[] {  
-  return products.filter(p => p.description.toLowerCase().includes(this.productName) &&
-                              checkDescr(p.descriptionExtended, this.productDescription));
+  return products.filter(p => checkDescr(p.descriptionExtended, this.productDescription));
 }
 
 function checkDescr(descr : string, filterDescr : string) : boolean {

--- a/src/app/components/search-products/search-products.component.ts
+++ b/src/app/components/search-products/search-products.component.ts
@@ -93,7 +93,7 @@ function prepareProduct(prod : Product) : Product {
 }
 
 function filterProducts(products: Product[]): Product[] {  
-  return products.filter(p => checkDescr(p.descriptionExtended, this.productDescription));
+  return products; //.filter(p => checkDescr(p.descriptionExtended, this.productDescription));
 }
 
 function checkDescr(descr : string, filterDescr : string) : boolean {


### PR DESCRIPTION
Risoluzione bug relativo alla ricerca di prodotti (tramite nome) quando non si accedeva alla specifica categoria.

Il bug era dovuto al fatto che il filtering sul nome del prodotto fosse eseguito lato client e non sfruttando l'API del server principale (campo "description" nella richiesta dei prodotti). Se quindi il prodotto ricercato non era fra il primo batch di prodotti ricevuti dal server la ricerca falliva.
Per evitare che un problema simile si verifichi anche nel caso del filtro di ricerca "descrizione del prodotto", l'ho disabilitato commentando le parti relative, non essendo disponibile una funzione di ricerca per descrizione estesa nell'API di cassanova.